### PR TITLE
feat: ResultDisplayStep UI 컴포넌트 구현

### DIFF
--- a/apps/tarote/src/features/tarotResult/ui/ResultDisplayStep/ResultDisplayStep.module.css
+++ b/apps/tarote/src/features/tarotResult/ui/ResultDisplayStep/ResultDisplayStep.module.css
@@ -1,0 +1,235 @@
+/* 🔮 결과 표시 단계 스타일 */
+
+.container {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #1e1b4b 0%, #312e81 50%, #1e1b4b 100%);
+  padding: 2rem 1rem;
+}
+
+.content {
+  max-width: 48rem;
+  margin: 0 auto;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.headerIcon {
+  font-size: 4rem;
+  margin-bottom: 1rem;
+  filter: drop-shadow(0 0 15px rgba(168, 85, 247, 0.6));
+}
+
+.title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  background: linear-gradient(45deg, #a855f7, #06b6d4);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  line-height: 1.2;
+}
+
+.subtitle {
+  font-size: 1.125rem;
+  color: #cbd5e1;
+  opacity: 0.9;
+}
+
+.section {
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1rem;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+}
+
+.sectionTitle {
+  display: flex;
+  align-items: center;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: white;
+  margin-bottom: 1.5rem;
+}
+
+.sectionIcon {
+  margin-right: 0.75rem;
+  font-size: 1.75rem;
+}
+
+.overallText {
+  font-size: 1.125rem;
+  line-height: 1.7;
+  color: #e2e8f0;
+  white-space: pre-line;
+}
+
+.cardsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.cardItem {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  transition: all 0.3s ease;
+}
+
+.cardItem:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(168, 85, 247, 0.3);
+  transform: translateY(-2px);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.cardPosition {
+  background: linear-gradient(45deg, #a855f7, #8b5cf6);
+  color: white;
+  border-radius: 50%;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.875rem;
+  margin-right: 0.75rem;
+  flex-shrink: 0;
+}
+
+.cardTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: white;
+  margin: 0;
+}
+
+.cardMeaning {
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #cbd5e1;
+  margin-bottom: 0.75rem;
+}
+
+.cardSymbolism {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.adviceText {
+  font-size: 1.125rem;
+  line-height: 1.7;
+  color: #e2e8f0;
+  white-space: pre-line;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 3rem;
+}
+
+.primaryButton {
+  background: linear-gradient(45deg, #a855f7, #8b5cf6);
+  color: white;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.875rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: 0 4px 14px 0 rgba(168, 85, 247, 0.25);
+}
+
+.primaryButton:hover {
+  background: linear-gradient(45deg, #9333ea, #7c3aed);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px 0 rgba(168, 85, 247, 0.35);
+}
+
+.secondaryButton {
+  background: transparent;
+  color: #e2e8f0;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 0.5rem;
+  padding: 0.875rem 2rem;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.secondaryButton:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.timestamp {
+  text-align: center;
+  font-size: 0.875rem;
+  color: #94a3b8;
+  margin-top: 2rem;
+  font-style: italic;
+}
+
+/* 반응형 */
+@media (max-width: 768px) {
+  .container {
+    padding: 1rem 0.5rem;
+  }
+
+  .title {
+    font-size: 1.75rem;
+  }
+
+  .subtitle {
+    font-size: 1rem;
+  }
+
+  .section {
+    padding: 1.5rem;
+  }
+
+  .sectionTitle {
+    font-size: 1.25rem;
+  }
+
+  .cardsGrid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .cardItem {
+    padding: 1.25rem;
+  }
+
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .primaryButton,
+  .secondaryButton {
+    width: 100%;
+  }
+}

--- a/apps/tarote/src/features/tarotResult/ui/ResultDisplayStep/ResultDisplayStep.tsx
+++ b/apps/tarote/src/features/tarotResult/ui/ResultDisplayStep/ResultDisplayStep.tsx
@@ -1,0 +1,160 @@
+// 🔮 결과 표시 단계 컴포넌트
+// AI가 생성한 타로 해석 결과를 보여주는 UI
+
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { TarotInterpretation } from '../../model/types';
+import styles from './ResultDisplayStep.module.css';
+
+interface ResultDisplayStepProps {
+  interpretation: TarotInterpretation;
+}
+
+export const ResultDisplayStep = ({ interpretation }: ResultDisplayStepProps) => {
+  const router = useRouter();
+
+  // 🔮 새로운 리딩 시작
+  const handleNewReading = () => {
+    router.push('/reading');
+  };
+
+  // 📱 결과 공유 (향후 구현)
+  const handleShare = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: 'Tarote - 나의 타로 리딩 결과',
+          text: '방금 받은 타로 해석 결과를 확인해보세요!',
+          url: window.location.href
+        });
+      } catch (error) {
+        // 공유 취소된 경우는 에러로 처리하지 않음
+        if ((error as Error).name !== 'AbortError') {
+          console.error('공유 실패:', error);
+          // 클립보드 복사로 폴백
+          fallbackCopyToClipboard();
+        }
+      }
+    } else {
+      // 네이티브 공유를 지원하지 않는 환경에서는 클립보드 복사
+      fallbackCopyToClipboard();
+    }
+  };
+
+  // 📋 클립보드 복사 폴백
+  const fallbackCopyToClipboard = () => {
+    navigator.clipboard.writeText(window.location.href)
+      .then(() => {
+        alert('결과 링크가 클립보드에 복사되었습니다!');
+      })
+      .catch(() => {
+        console.error('클립보드 복사 실패');
+      });
+  };
+
+  // 📅 날짜 포맷팅
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.content}>
+        {/* 헤더 */}
+        <div className={styles.header}>
+          <div className={styles.headerIcon}>🔮</div>
+          <h1 className={styles.title}>
+            당신의 타로 해석 결과
+          </h1>
+          <p className={styles.subtitle}>
+            AI가 카드들의 의미를 깊이 분석한 결과입니다
+          </p>
+        </div>
+
+        {/* 전체 해석 */}
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>
+            <span className={styles.sectionIcon}>✨</span>
+            전체적인 해석
+          </h2>
+          <p className={styles.overallText}>
+            {interpretation.overall}
+          </p>
+        </section>
+
+        {/* 카드별 의미 */}
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>
+            <span className={styles.sectionIcon}>🃏</span>
+            카드별 의미
+          </h2>
+          <div className={styles.cardsGrid}>
+            {interpretation.cardMeanings.map((card) => (
+              <div key={`${card.cardId}-${card.position}`} className={styles.cardItem}>
+                <div className={styles.cardHeader}>
+                  <div className={styles.cardPosition}>
+                    {card.position}
+                  </div>
+                  <h3 className={styles.cardTitle}>
+                    카드 #{card.cardId}
+                  </h3>
+                </div>
+                <p className={styles.cardMeaning}>
+                  {card.meaning}
+                </p>
+                {card.symbolism && (
+                  <p className={styles.cardSymbolism}>
+                    상징: {card.symbolism}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* 조언 */}
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>
+            <span className={styles.sectionIcon}>💡</span>
+            조언 및 제안
+          </h2>
+          <p className={styles.adviceText}>
+            {interpretation.advice}
+          </p>
+        </section>
+
+        {/* 액션 버튼들 */}
+        <div className={styles.actions}>
+          <button
+            className={styles.primaryButton}
+            onClick={handleNewReading}
+            type="button"
+          >
+            새로운 리딩 시작하기
+          </button>
+
+          <button
+            className={styles.secondaryButton}
+            onClick={handleShare}
+            type="button"
+          >
+            결과 공유하기
+          </button>
+        </div>
+
+        {/* 타임스탬프 */}
+        <div className={styles.timestamp}>
+          해석 생성 시간: {formatDate(interpretation.generatedAt)}
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
타로 해석 결과 표시 메인 컴포넌트 (395 lines) - 전체 해석, 카드별 의미, 조언 섹션과 네이티브 공유 기능 구현

## Changes
- `ResultDisplayStep.tsx`: 결과 표시 컴포넌트 (160 lines)
- `ResultDisplayStep.module.css`: 포괄적 스타일링 (235 lines)
- 전체 해석 및 카드별 의미 표시
- 네이티브 공유 API 및 클립보드 폴백
- 반응형 그리드 레이아웃
- 글래스모피즘 디자인 및 호버 효과
- 새로운 리딩 시작 및 공유 기능

## Test plan
- [ ] 타로 결과 데이터 표시 확인
- [ ] 카드별 의미 그리드 레이아웃 테스트
- [ ] 공유 기능 및 클립보드 폴백 검증
- [ ] 반응형 디자인 테스트
- [ ] 접근성 및 키보드 네비게이션

---

**변경 유형**: feat
**변경 규모**: large
**영향 범위**: frontend