### PR TITLE
feat: 타로 결과 페이지 통합 구현

### DIFF
--- a/apps/tarote/src/app/result/page.tsx
+++ b/apps/tarote/src/app/result/page.tsx
@@ -1,0 +1,37 @@
+// 🔮 타로 결과 페이지
+// AI 해석 결과를 확인하는 페이지 (회원가입 유도 포함)
+
+import { Suspense } from 'react';
+import { TarotResultProvider } from '../../features/tarotResult/model/provider';
+import { TarotResultFlow } from '../../features/tarotResult/ui/TarotResultFlow/TarotResultFlow';
+
+// 🔄 로딩 컴포넌트
+const ResultPageLoading = () => (
+  <div className="flex items-center justify-center min-h-screen">
+    <div className="text-center">
+      <div className="animate-spin w-8 h-8 border-4 border-purple-200 border-t-purple-600 rounded-full mx-auto mb-4"></div>
+      <p className="text-gray-600">결과를 불러오고 있습니다...</p>
+    </div>
+  </div>
+);
+
+export default function ResultPage() {
+  return (
+    <TarotResultProvider>
+      <Suspense fallback={<ResultPageLoading />}>
+        <TarotResultFlow />
+      </Suspense>
+    </TarotResultProvider>
+  );
+}
+
+// 📄 페이지 메타데이터
+export const metadata = {
+  title: 'Tarote - 타로 해석 결과',
+  description: 'AI가 분석한 당신의 타로 카드 해석 결과를 확인해보세요.',
+  openGraph: {
+    title: 'Tarote - 타로 해석 결과',
+    description: 'AI가 분석한 당신의 타로 카드 해석 결과를 확인해보세요.',
+    type: 'website',
+  },
+};

--- a/apps/tarote/src/features/tarotResult/ui/TarotResultFlow/TarotResultFlow.tsx
+++ b/apps/tarote/src/features/tarotResult/ui/TarotResultFlow/TarotResultFlow.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+// 🎭 TarotResult 메인 플로우 컴포넌트
+// 요청 상태에 따라 적절한 UI 컴포넌트를 렌더링
+
+import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useTarotResult } from '../../model/provider';
+import { LoadingStep } from '../LoadingStep/LoadingStep';
+import { LoginPromptStep } from '../LoginPromptStep/LoginPromptStep';
+import { ResultDisplayStep } from '../ResultDisplayStep/ResultDisplayStep';
+import { ErrorStep } from '../ErrorStep/ErrorStep';
+
+export const TarotResultFlow = () => {
+  const searchParams = useSearchParams();
+  const {
+    requestStatus,
+    error,
+    interpretation,
+    initializeFromUrl,
+    retryPolling
+  } = useTarotResult();
+
+  // 🚀 페이지 로드 시 URL params에서 초기화
+  useEffect(() => {
+    if (searchParams) {
+      initializeFromUrl(searchParams);
+    }
+  }, [searchParams, initializeFromUrl]);
+
+  // 🎨 상태별 컴포넌트 렌더링
+  switch (requestStatus) {
+    case 'idle':
+    case 'creating':
+      return (
+        <div className="flex items-center justify-center min-h-screen">
+          <div className="text-center">
+            <div className="animate-spin w-8 h-8 border-4 border-purple-200 border-t-purple-600 rounded-full mx-auto mb-4"></div>
+            <p className="text-gray-600">요청을 준비하고 있습니다...</p>
+          </div>
+        </div>
+      );
+
+    case 'pending':
+    case 'processing':
+      return <LoadingStep />;
+
+    case 'access_denied':
+      return <LoginPromptStep />;
+
+    case 'completed':
+      if (!interpretation) {
+        return (
+          <ErrorStep
+            error="결과를 불러올 수 없습니다."
+            onRetry={retryPolling}
+          />
+        );
+      }
+      return <ResultDisplayStep interpretation={interpretation} />;
+
+    case 'failed':
+      return (
+        <ErrorStep
+          error={error || '알 수 없는 오류가 발생했습니다.'}
+          onRetry={retryPolling}
+        />
+      );
+
+    default:
+      return (
+        <ErrorStep
+          error="알 수 없는 상태입니다."
+          onRetry={retryPolling}
+        />
+      );
+  }
+};


### PR DESCRIPTION
## Summary
타로 결과 페이지 통합 구현 (115 lines) - Next.js 페이지 레벨 통합 및 플로우 컨트롤러로 모든 UI 컴포넌트 연결 및 상태 관리

## Changes
- `page.tsx`: Next.js 결과 페이지 (37 lines)
- `TarotResultFlow.tsx`: 상태별 플로우 컨트롤러 (78 lines)
- URL 파라미터 기반 초기화
- Suspense 및 로딩 상태 처리
- 메타데이터 및 OpenGraph 설정
- 상태별 컴포넌트 렌더링 로직

## Test plan
- [ ] URL 파라미터 기반 페이지 로드 확인
- [ ] 각 상태별 컴포넌트 렌더링 테스트
- [ ] 에러 상태 처리 검증
- [ ] 메타데이터 및 SEO 태그 확인

---

**변경 유형**: feat
**변경 규모**: medium
**영향 범위**: frontend