### PR TITLE
docs: Claude Code 자동 생성 메시지 금지 규칙 추가

### DIFF
--- a/AGENT-GUIDE.md
+++ b/AGENT-GUIDE.md
@@ -1,6 +1,7 @@
 # KB-Store Development Guide
 
 ## 🛠️ 개발 환경
+
 - **Node.js**: v18+
 - **Package Manager**: pnpm
 - **Framework**: Next.js 15
@@ -9,6 +10,7 @@
 ## 📐 아키텍처 규칙
 
 ### FSD (Feature-Sliced Design)
+
 ```
 app/     # 앱 레벨 설정
 pages/   # 페이지 라우팅
@@ -19,23 +21,55 @@ shared/  # 공통 코드
 ```
 
 ### 브랜치 전략
+
 - `main`: 프로덕션 브랜치
 - `feature/[app-name].[feature-name]`: 기능 브랜치
 - **PR 크기 제한**: 200줄 내외 (맥락을 강제로 끊는 경우 제외)
 
 ## 📋 문서화 표준
+
 - **CLAUDE.md**: 비즈니스 명세 (기획자용)
 - **AGENT-GUIDE.md**: 기술 구현 가이드 (개발자용)
 
-## 📝 PR 작성 규칙 (Base Rule)
-- **템플릿 준수**: `.github/pull_request_template.md` 필수 사용
-- **크기 제한**: 200줄 내외 (맥락을 강제로 끊는 경우 제외)
-- **체크리스트**: 모든 해당 항목 완료 후 PR 생성
+## 📝 커밋 및 PR 작성 규칙 (Base Rule)
+
+### 커밋 메시지 규칙
+
+- **Claude Code 관련 자동 생성 메시지 금지**
+  - `🤖 Generated with [Claude Code](https://claude.ai/code)` 형태의 메시지 사용 금지
+  - `Co-Authored-By: Claude <noreply@anthropic.com>` 형태의 메시지 사용 금지
+  - AI 도구 사용 흔적을 커밋 메시지에 남기지 않음
+- **컨벤셔널 커밋**: feat, fix, docs 등 타입 명시
+- **명확한 설명**: 변경사항의 목적과 내용을 간결하게 작성
+
+### PR 생성 및 변경사항 측정 규칙
+
+- **정확한 diff line 측정**: `git diff --cached --stat` 명령어로 정확한 변경 라인 수 측정
+- **현재 브랜치 전체 변경사항 측정**: `git diff main...HEAD --stat`
+- **추가/수정/삭제 라인 수 확인**: `git diff --cached --numstat`
+
+### PR 크기 제한 및 라벨링
+
+- **size/small**: ~100 lines
+- **size/medium**: 100-200 lines
+- **size/large**: 200+ lines
+- **200 라인 초과 시**: 반드시 더 작은 PR로 분할 고려
+- **테스트 파일 예외**: 230라인까지 허용 (충분한 테스트 커버리지 확보 목적)
+
+### PR 템플릿 준수
+
+- **템플릿 필수 사용**: `.github/pull_request_template.md` 형식 준수
+- **Summary**: 간단한 설명
+- **Changes**: 주요 변경사항
+- **Test plan**: 테스트 방법
+- **메타데이터**: 변경 유형, 규모, 영향 범위 명시
 
 ## 🧪 테스트 전략
+
 - **단위 테스트**: Vitest
 - **E2E 테스트**: Playwright
 - **커버리지**: 핵심 비즈니스 로직 100%
 
 ---
+
 📍 각 앱별 기술 가이드는 해당 디렉토리의 AGENT-GUIDE.md를 참조하세요.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# React Example 01
+
+이 레포지토리는 **Tanstack Query**, **Tanstack Virtual**, **Zustand**를 활용한 React 예제 애플리케이션입니다.  
+데이터 비동기 처리, 리스트 가상 스크롤, 글로벌 상태 관리를 심플한 예제로 구현하여, 실제 개발 환경에서 직관적으로 사용할 수 있는 코드 구조를 보여줍니다.
+
+## 주요 기능
+1. **데이터 페칭 & 캐싱**: Tanstack Query를 통해 API 응답을 캐싱하고, 비동기처리 상태를 쉽게 처리
+2. **가상 스크롤 목록**: Tanstack Virtual을 사용하여 긴 목록을 스크롤에 대한 성능 최적화
+3. **전역 상태 관리**: Zustand로 전역 상태를 통한 Tab 메뉴 관리
+
+## Demo
+https://githubbox.com/pmmm114/react-example-01/tree/develop

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 각 apps의 Readme에 기술
 
 ## Demo
-[https://githubbox.com/pmmm114/react-example-01/tree/develop](https://github.com/pmmm114/KB-Store/tree/develop)
+[https://githubbox.com/pmmm114/KB-Store/tree/develop](https://github.com/pmmm114/KB-Store/tree/develop)

--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@
 
 ## 프로젝트 설명
 각 apps의 Readme에 기술
+
+## Demo
+[https://githubbox.com/pmmm114/react-example-01/tree/develop](https://github.com/pmmm114/KB-Store/tree/develop)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
-# React Example 01
+# KB-Store
+## 목적
+어플리케이션 데모 및 토이프로젝트
 
-이 레포지토리는 **Tanstack Query**, **Tanstack Virtual**, **Zustand**를 활용한 React 예제 애플리케이션입니다.  
-데이터 비동기 처리, 리스트 가상 스크롤, 글로벌 상태 관리를 심플한 예제로 구현하여, 실제 개발 환경에서 직관적으로 사용할 수 있는 코드 구조를 보여줍니다.
-
-## 주요 기능
-1. **데이터 페칭 & 캐싱**: Tanstack Query를 통해 API 응답을 캐싱하고, 비동기처리 상태를 쉽게 처리
-2. **가상 스크롤 목록**: Tanstack Virtual을 사용하여 긴 목록을 스크롤에 대한 성능 최적화
-3. **전역 상태 관리**: Zustand로 전역 상태를 통한 Tab 메뉴 관리
-
-## Demo
-https://githubbox.com/pmmm114/react-example-01/tree/develop
+## 프로젝트 설명
+각 apps의 Readme에 기술


### PR DESCRIPTION
## Summary
AGENT-GUIDE.md에 Claude Code 관련 자동 생성 메시지 사용을 금지하는 base rule을 추가했습니다. 깔끔한 커밋 히스토리 유지를 위해 AI 도구 사용 흔적을 커밋 메시지에 남기지 않도록 규정했습니다.

## Changes
- AGENT-GUIDE.md 파일 생성 및 기본 개발 가이드 추가
- Claude Code 자동 생성 메시지 사용 금지 규칙 추가
- 정확한 diff line 측정 방법 명시
- PR 크기 제한 및 라벨링 규칙 상세화
- PR 템플릿 준수 요구사항 추가
- 커밋 및 PR 작성 규칙 체계화

## Test plan
- [x] AGENT-GUIDE.md 문서 구조 검증
- [x] 새로운 규칙이 명확하게 설명되었는지 확인
- [x] 기존 개발 프로세스와의 일관성 확인

## Additional context
이 규칙은 앞으로 모든 개발 작업에서 준수해야 하는 base rule입니다. 특히 AI 도구를 사용한 개발에서도 전문적인 커밋 히스토리를 유지할 수 있도록 합니다.

---

**변경 유형**: docs
**변경 규모**: medium
**영향 범위**: docs